### PR TITLE
Change to correct URLs of cargonizer endpoints

### DIFF
--- a/src/zaporylie/Cargonizer/Config.php
+++ b/src/zaporylie/Cargonizer/Config.php
@@ -13,8 +13,8 @@ use Http\Discovery\HttpClientDiscovery;
  */
 class Config
 {
-  const SANDBOX = 'http://sandbox.cargonizer.no';
-  const PRODUCTION = 'http://cargonizer.no';
+  const SANDBOX = 'https://sandbox.cargonizer.no';
+  const PRODUCTION = 'https://cargonizer.no';
 
   protected static $config = [
     'endpoint' => self::SANDBOX,


### PR DESCRIPTION
The endpoints for cargonizer have changed to force redirect to https.

In this package, the http client is not configured to automatically follow redirects, resulting in results that are often `FALSE` when they could have been `\SimpleXMLElement`

This for example results in 

```
TypeError: Argument 1 passed to zaporylie\Cargonizer\Data\Results::fromXML() must be an instance of SimpleXMLElement, boolean given
```

in the method Partners::getPickupPoints()

This PR changes the URLs, so this will not happen in these very consistens cases. However, it should probably not try to call ::fromXml when we do not have an XML to work with.